### PR TITLE
Add documentation on roadmap and implementation

### DIFF
--- a/site/docs/src/SUMMARY.md
+++ b/site/docs/src/SUMMARY.md
@@ -21,4 +21,5 @@
     - [Specification.Wallet.Payment](./design/Specification/Wallet/Payment.lagda.md)
     - [Specification.Wallet.UTxO](./design/Specification/Wallet/UTxO.lagda.md)
   - [Implementation](./design/implementation.md)
+  - [Roadmap](./design/roadmap.md)
 - [Contributing](./contributing.md)

--- a/site/docs/src/design/implementation.md
+++ b/site/docs/src/design/implementation.md
@@ -1,6 +1,68 @@
-Implementation.
+# Implementation: Customer Deposit Wallet
 
-Miscellaneous details, such as
+  [cdw]: https://github.com/cardano-foundation/cardano-deposit-wallet
 
-* Agda2hs. Status of specification.
-* `Pure`, `IO`, `REST`, and `HTTP` modules.
+This document describes selected aspects of the current implementation of the [Cardano Deposit Wallet][cdw].
+
+We focus on aspects that are about the overall organization of the source code and cannot be learned by looking at individual files.
+
+TODO: This document needs to become part of the source code.
+
+# Repositories
+
+The source code for the [Cardano Deposit Wallet][cdw] is currently split over several repositories and packages:
+
+* Repo [cardano-wallet-agda][]
+
+  * Package [customer-deposit-wallet-pure][]
+    * Specification.
+    * Implementation of main pieces of functionality using [Agda2hs][], in a purely functional style.
+
+  * Package [customer-deposit-wallet-pure][] — helper library. Also exported to [agda2hs][].
+
+* Repo [cardano-wallet][]
+
+  * Package [customer-deposit-wallet][] — Package that assembles the pieces of functionality from [customer-deposit-wallet-pure][] and makes them useable in imperative styles.
+
+  * Package [customer-deposit-wallet-ui][] — Package that presents a web UI for the Deposit Wallet.
+
+  * Package `network-layer`, … — helper packages.
+
+  * Executable `cardano-wallet` — currently contains both the legacy `cardano-wallet` and the Deposit Wallet with UI.
+
+* Repo [cardano-deposit-wallet][]
+
+  * Provides releases containing the executable.
+
+  * Documentation.
+
+  [agda2hs]: https://github.com/agda/agda2hs
+  [cardano-wallet]: https://github.com/cardano-foundation/cardano-wallet
+  [cardano-wallet-agda]: https://github.com/cardano-foundation/cardano-wallet-agda
+  [customer-deposit-wallet]: https://github.com/cardano-foundation/cardano-wallet/tree/master/lib/customer-deposit-wallet
+  [customer-deposit-wallet-ui]: https://github.com/cardano-foundation/cardano-wallet/tree/master/lib/ui
+  [customer-deposit-wallet-pure]: https://github.com/cardano-foundation/cardano-wallet-agda/tree/main/lib/customer-deposit-wallet-pure
+  [cardano-deposit-wallet]: https://github.com/cardano-foundation/cardano-deposit-wallet/
+
+# Conformance to Specification
+
+The package [customer-deposit-wallet-pure][] contains both the specification and and implementation of various aspects of functionality. Some of these aspects come with proofs. An experimental implementation combines the aspects and proves a few properties of the Specification.
+
+However, the actual implementation in [customer-deposit-wallet][] has not been proven or tested correct with respect to the Specification yet.
+
+# Module Organization
+
+The package [customer-deposit-wallet][] is organized into modules with the prefix `Cardano.Wallet.Deposit.*`.
+
+In turn, this prefix is organized into groups of modules. These groups build on top of each other — each group wraps the previous group, moving from purely functional style to an imperative style, with more and more integration with the operating system and other interfaces.
+
+The succession of module groups is:
+
+1. `Pure` — Implementation in purely functional style: only data types and pure functions on it.
+2. `IO` — Straightforward wrapper of the pure functions into an interface with implicit control flow (mutable state, exceptions, concurrency).
+3. `REST` — Straightforward wrapper of `IO` into an API that aligns with REST principles.
+4. `HTTP` — Straightforward wrapper of `REST` into an HTTP API.
+
+The package [customer-deposit-wallet-ui][] add the group
+
+4'. `UI` — Presentation of `REST` as a web UI.

--- a/site/docs/src/design/roadmap.md
+++ b/site/docs/src/design/roadmap.md
@@ -1,0 +1,38 @@
+# Roadmap: Cardano Deposit Wallet
+
+  [cdw]: https://github.com/cardano-foundation/cardano-deposit-wallet
+
+This roadmap describes potential directions for the [Cardano Deposit Wallet][cdw].
+
+# Minimium Viable Product
+
+Production readiness:
+
+* Separate executable:
+  `cardano-deposit-wallet`.
+* Persistence:
+  The wallet state is stored on disk and does not have to be resynchronized every time that the deposit wallet process is started.
+* REST API: For interacting with the wallet.
+
+# Future work, potential
+
+* Formal methods
+
+  * Prove the implementation correct with respect to the specification.
+
+* Refunds
+
+   * Create transaction that refunds any UTxO from a customer — but which the wallet does not accept (e.g. because they contain NFTs). The user has to pay the transaction fee.
+
+* Staking?
+
+  * Delegate wallet funds to a stake pool.
+
+  * A transaction output can belong to the wallet but may have a [delegation part][addr] that points to a stake pool.
+
+    * Users can stake with the funds as long as possible?
+
+    * Should we make a transaction that moves those funds to a different delegation address?
+
+
+  [addr]: https://github.com/cardano-foundation/CIPs/tree/master/CIP-0019#shelley-addresses


### PR DESCRIPTION
This pull request adds the following documentation:

* Roadmap — records potential and future work.
* Implementation — records selected implementation aspects, in particular those that are about the overall organization of the source code and cannot be learned by looking at individual source code files.

Fix #11