### PR TITLE
Add mithril support to docker compose

### DIFF
--- a/run/docker/docker-compose.yml
+++ b/run/docker/docker-compose.yml
@@ -50,3 +50,14 @@ services:
         compress: "true"
         max-file: "10"
         max-size: "50m"
+
+  mithril:
+    image: ghcr.io/input-output-hk/mithril-client:${MITHRIL_TAG}
+    user: ${USER_ID}:${GROUP_ID}
+    volumes:
+      - ${NODE_DB}:/app/db
+    environment:
+      AGGREGATOR_ENDPOINT: ${AGGREGATOR_ENDPOINT}
+      GENESIS_VERIFICATION_KEY: ${GENESIS_VERIFICATION_KEY}
+    profiles:
+      - mithril


### PR DESCRIPTION
### Changes

- Add a container definition to run mithril from the docker compose. 
- Segregate the mithril container definition using a seprate profile

### Issues

#9

### Notes

A necessary PR to have a docker-compose in main which covers the needs for the docker based installation instructions