### PR TITLE
Follow redirects when resolving the latest Mithril release

### DIFF
--- a/site/docs/src/installation/mithril.md
+++ b/site/docs/src/installation/mithril.md
@@ -16,9 +16,9 @@ case $PACKAGED_FOR in
         exit 1
         ;;
 esac
-LATEST_MITHRIL=$(curl -sL https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r .tag_name)
+LATEST_MITHRIL=$(curl -sL https://api.github.com/repos/IntersectMBO/mithril/releases/latest | jq -r .tag_name)
 MITHRIL_NAME=mithril-$LATEST_MITHRIL-$MITHRIL_PLATFORM
-wget -q https://github.com/input-output-hk/mithril/releases/download/$LATEST_MITHRIL/$MITHRIL_NAME.tar.gz
+wget -q https://github.com/IntersectMBO/mithril/releases/download/$LATEST_MITHRIL/$MITHRIL_NAME.tar.gz
 MITHRIL_DIR=$(pwd)/$MITHRIL_NAME
 mkdir -p "$MITHRIL_DIR"
 tar xvzf "$MITHRIL_NAME.tar.gz" -C "$MITHRIL_DIR" > /dev/null

--- a/site/docs/src/installation/mithril.md
+++ b/site/docs/src/installation/mithril.md
@@ -16,7 +16,7 @@ case $PACKAGED_FOR in
         exit 1
         ;;
 esac
-LATEST_MITHRIL=$(curl -s https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r .tag_name)
+LATEST_MITHRIL=$(curl -sL https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r .tag_name)
 MITHRIL_NAME=mithril-$LATEST_MITHRIL-$MITHRIL_PLATFORM
 wget -q https://github.com/input-output-hk/mithril/releases/download/$LATEST_MITHRIL/$MITHRIL_NAME.tar.gz
 MITHRIL_DIR=$(pwd)/$MITHRIL_NAME


### PR DESCRIPTION
This PR includes a **hardening of the Mithril release lookup in the installation documentation**:

- Add `-L` to the curl call resolving the latest Mithril release in `site/docs/src/installation/mithril.md`, so the lookup keeps working if the GitHub API responds with redirects
- Update the Mithril reository to `IntersectMBO` organization

### Notes

- This code block is also executed by the docs-test CI jobs (`download-mithril.yml`, `build-and-install-package-with-mithril.yml`), so the change keeps them future proof as well
- The `wget` call downloading the release archive already follows redirects and needs no change